### PR TITLE
Fix: HTML code wrapped non .html files with Front Matter

### DIFF
--- a/lib/jekyll-external-links/external_links.rb
+++ b/lib/jekyll-external-links/external_links.rb
@@ -42,8 +42,8 @@ def mark_links_in_page_or_document(page_or_document)
     'a[href*=coverity]',
     'a[href*=codecov]',
   ]
-
-  unless page_or_document.respond_to?(:asset_file?) and page_or_document.asset_file?
+  
+  unless (page_or_document.respond_to?(:asset_file?) and page_or_document.asset_file?) or page_or_document.output_ext != ".html"
     page_or_document.output = process_content(
       site_hostname,
       page_or_document.output,


### PR DESCRIPTION
Hi,

The plugin works great! But it also parsed non .html files with Front Matter so I went ahead and fix it. The error output can be seen at https://gitlab.com/DiscourseForum/DiscourseThemes/-/commit/64ee62c60ec408e6e3561aa314b39c190aff80e0 .

Let me know if you have any questions.

Thank you!